### PR TITLE
Fix cannot find module 'versor/src/index'

### DIFF
--- a/src/geoZoom.js
+++ b/src/geoZoom.js
@@ -1,6 +1,6 @@
 import { select as d3Select, pointers as d3Pointers } from 'd3-selection';
 import { zoom as d3Zoom } from 'd3-zoom';
-import versor from 'versor/src/index';
+import versor from 'versor';
 import Kapsule from 'kapsule';
 
 export default Kapsule({


### PR DESCRIPTION
Fixes the error `Cannot find module 'versor/src/index'` on `versor 0.2.0` by updating the import to:
```
import versor from 'versor';
```

Even though the code was originally targeting `versor: ~0.1.2`, this change also ensures compatibility with `versor: 0.2.0` by handling its stricter exports field.